### PR TITLE
Fix driver for linux >= 4.8

### DIFF
--- a/driver/linux/riffa_driver.c
+++ b/driver/linux/riffa_driver.c
@@ -443,8 +443,10 @@ static inline struct sg_mapping * fill_sg_buf(struct fpga_state * sc, int chnl,
 		down_read(&current->mm->mmap_sem);
 		#if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
 		num_pages = get_user_pages(current, current->mm, udata, num_pages_reqd, 1, 0, pages, NULL);
-		#else
+		#elsif LINUX_VERSION_CODE < KERNEL_VERSION(4,9,0)
 		num_pages = get_user_pages(udata, num_pages_reqd, 1, 0, pages, NULL);
+		#else
+		num_pages = get_user_pages(udata, num_pages_reqd, FOLL_WRITE, pages, NULL);
 		#endif
 		up_read(&current->mm->mmap_sem);
 		if (num_pages <= 0) {

--- a/driver/linux/riffa_driver.c
+++ b/driver/linux/riffa_driver.c
@@ -1530,7 +1530,12 @@ static void __devexit fpga_remove(struct pci_dev *dev)
 // MODULE INIT/EXIT FUNCTIONS
 ///////////////////////////////////////////////////////
 
-static DEFINE_PCI_DEVICE_TABLE(fpga_ids) = {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)
+static DEFINE_PCI_DEVICE_TABLE(fpga_ids) =
+#else
+static const struct pci_device_id fpga_ids[] =
+#endif
+{
 	{PCI_DEVICE(VENDOR_ID0, PCI_ANY_ID)},
 	{PCI_DEVICE(VENDOR_ID1, PCI_ANY_ID)},
 	{0},

--- a/driver/linux/riffa_driver.c
+++ b/driver/linux/riffa_driver.c
@@ -247,6 +247,12 @@ int pcie_capability_write_dword(struct pci_dev *dev, int pos, u32 val)
 }
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+	#define pci_alloc_consistent(d, s, a)     dma_alloc_coherent(&(d)->dev, s, a, GFP_ATOMIC)
+	#define pci_free_consistent(d, s, a, b)   dma_free_coherent(&(d)->dev, s, a, b)
+	#define pci_set_dma_mask(d, m)            dma_set_mask(&(d)->dev, m)
+	#define pci_set_consistent_dma_mask(d, m) dma_set_coherent_mask(&(d)->dev, m)
+#endif
 
 
 

--- a/driver/linux/riffa_driver.c
+++ b/driver/linux/riffa_driver.c
@@ -51,7 +51,13 @@
 #include <linux/fs.h>
 #include <linux/pci.h>
 #include <linux/interrupt.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,11,0)
 #include <linux/sched.h>
+#else
+#include <linux/sched/signal.h>
+#endif
+
 #include <linux/rwsem.h>
 #include <linux/dma-mapping.h>
 #include <linux/pagemap.h>


### PR DESCRIPTION
This fixes driver compilation for at least Linux 4.8.13.
This preprocessor check: 
LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)
solves this issue but the exact Linux minor version which removed macro DEFINE_PCI_DEVICE_TABLE is unknown. But I think it's no big deal.
