### PR TITLE
riffa_driver.c: #elsif typo fixed

### DIFF
--- a/driver/linux/riffa_driver.c
+++ b/driver/linux/riffa_driver.c
@@ -461,7 +461,7 @@ static inline struct sg_mapping * fill_sg_buf(struct fpga_state * sc, int chnl,
 
 		#if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
 		num_pages = get_user_pages(current, current->mm, udata, num_pages_reqd, 1, 0, pages, NULL);
-		#elsif LINUX_VERSION_CODE < KERNEL_VERSION(4,9,0)
+		#elif LINUX_VERSION_CODE < KERNEL_VERSION(4,9,0)
 		num_pages = get_user_pages(udata, num_pages_reqd, 1, 0, pages, NULL);
 		#else
 		num_pages = get_user_pages(udata, num_pages_reqd, FOLL_WRITE, pages, NULL);


### PR DESCRIPTION
#elsif directive is'nt defined. The correct one is #elif.